### PR TITLE
fixed hour 12 local storage bug

### DIFF
--- a/Assets/script.js
+++ b/Assets/script.js
@@ -22,7 +22,7 @@ $(window).ready(function () {
   $("#hour-9 .description").val(localStorage.getItem("hour-9"))
   $("#hour-10 .description").val(localStorage.getItem("hour-10"))
   $("#hour-11 .description").val(localStorage.getItem("hour-11"))
-  $("#hour-12 .description").val(localStorage.getItem("hour-13"))
+  $("#hour-12 .description").val(localStorage.getItem("hour-12"))
   $("#hour-13 .description").val(localStorage.getItem("hour-13"))
   $("#hour-14 .description").val(localStorage.getItem("hour-14"))
   $("#hour-15 .description").val(localStorage.getItem("hour-15"))


### PR DESCRIPTION
  $("#hour-9 .description").val(localStorage.getItem("hour-9"))
  $("#hour-10 .description").val(localStorage.getItem("hour-10"))
  $("#hour-11 .description").val(localStorage.getItem("hour-11"))

  $("#hour-12 .description").val(localStorage.getItem("hour-13")) -----> 
  $("#hour-12 .description").val(localStorage.getItem("hour-12"))


  $("#hour-13 .description").val(localStorage.getItem("hour-13")) 
  $("#hour-14 .description").val(localStorage.getItem("hour-14"))
  $("#hour-15 .description").val(localStorage.getItem("hour-15"))
  $("#hour-16 .description").val(localStorage.getItem("hour-16"))
  $("#hour-17 .description").val(localStorage.getItem("hour-18"))